### PR TITLE
fix(core): handle invalid resource requests

### DIFF
--- a/tests/data/empty_response.txt
+++ b/tests/data/empty_response.txt
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><rss version="2.0"><channel></channel></rss>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -103,3 +103,52 @@ def test_get_sources_page_timeout(client, rss_client, mocked_response):
 
     assert response.data
     assert response.status_code == 500
+
+
+def test_get_nonexistent_movies_page(client, rss_client, mocked_response):
+    with open(Path(const.EMPTY_RESP_FILE), 'rb') as resp:
+        mocked_response.add(
+            responses.GET,
+            rss_client.build_movies_uri('invalid-category', '1'),
+            body=resp, status=200
+        )
+        response = client.get('/movies/invalid-category/1')
+
+        assert response.data
+        assert response.status_code == 404
+
+
+def test_get_nonexistent_shows_page(client, rss_client, mocked_response):
+    with open(Path(const.EMPTY_RESP_FILE), 'rb') as resp:
+        mocked_response.add(
+            responses.GET, rss_client.build_shows_uri('invalid-category', '1'),
+            body=resp, status=200
+        )
+        response = client.get('/shows/invalid-category/1')
+
+        assert response.data
+        assert response.status_code == 404
+
+
+def test_get_nonexistent_episodes_page(client, rss_client, mocked_response):
+    with open(Path(const.EMPTY_RESP_FILE), 'rb') as resp:
+        mocked_response.add(
+            responses.GET, rss_client.build_episodes_uri('invalid-show', '1'),
+            body=resp, status=200
+        )
+        response = client.get('/episodes/invalid-show/1')
+
+        assert response.data
+        assert response.status_code == 404
+
+
+def test_get_nonexistent_sources_page(client, rss_client, mocked_response):
+    with open(Path(const.EMPTY_RESP_FILE), 'rb') as resp:
+        mocked_response.add(
+           responses.GET, rss_client.build_sources_uri('invalid-ep'),
+           body=resp, status=200
+        )
+        response = client.get('/sources/invalid-ep')
+
+        assert response.data
+        assert response.status_code == 404

--- a/tests/test_rss_client.py
+++ b/tests/test_rss_client.py
@@ -5,7 +5,7 @@ import requests
 import responses
 
 from website import const
-from website.rss_client import ClientTimeoutError
+from website.rss_client import ClientTimeoutError, InvalidResourceError
 
 
 def test_get_movies(rss_client, mocked_response):
@@ -106,3 +106,47 @@ def test_get_sources_timed_out(rss_client, mocked_response):
 
     with pytest.raises(ClientTimeoutError):
         rss_client.get_sources('99999')
+
+
+def test_get_invalid_movie(rss_client, mocked_response):
+    with open(Path(const.EMPTY_RESP_FILE), 'rb') as resp:
+        mocked_response.add(
+            responses.GET, rss_client.build_movies_uri('invalid-movie', '1'),
+            body=resp, status=200
+        )
+
+        with pytest.raises(InvalidResourceError):
+            rss_client.get_movies('invalid-movie', '1')
+
+
+def test_get_invalid_show(rss_client, mocked_response):
+    with open(Path(const.EMPTY_RESP_FILE), 'rb') as resp:
+        mocked_response.add(
+            responses.GET, rss_client.build_shows_uri('invalid-show', '1'),
+            body=resp, status=200
+        )
+
+        with pytest.raises(InvalidResourceError):
+            rss_client.get_shows('invalid-show', '1')
+
+
+def test_get_invalid_episode(rss_client, mocked_response):
+    with open(Path(const.EMPTY_RESP_FILE), 'rb') as resp:
+        mocked_response.add(
+            responses.GET, rss_client.build_episodes_uri('invalid-ep', '1'),
+            body=resp, status=200
+        )
+
+        with pytest.raises(InvalidResourceError):
+            rss_client.get_episodes('invalid-ep', '1')
+
+
+def test_get_invalid_sources(rss_client, mocked_response):
+    with open(Path(const.EMPTY_RESP_FILE), 'rb') as resp:
+        mocked_response.add(
+            responses.GET, rss_client.build_sources_uri('invalid-source'),
+            body=resp, status=200
+        )
+
+        with pytest.raises(InvalidResourceError):
+            rss_client.get_sources('invalid-source')

--- a/website/const.py
+++ b/website/const.py
@@ -8,12 +8,14 @@ SHOWS_RESP_FILE = 'tests/data/show_response.txt'
 SINGLE_SHOW_FILE = 'tests/data/single_show.txt'
 EPISODES_RESP_FILE = 'tests/data/episode_response.txt'
 SOURCES_RESP_FILE = 'tests/data/sources_response.txt'
+EMPTY_RESP_FILE = 'tests/data/empty_response.txt'
 
 # template paths
 MOVIES_TEMPLATE = 'core/movies.html'
 SHOWS_TEMPLATE = 'core/shows.html'
 EPISODES_TEMPLATE = 'core/episodes.html'
 SOURCES_TEMPLATE = 'core/sources.html'
+USER_ERROR_TEMPLATE = '404.html'
 SERVER_ERROR_TEMPLATE = '500.html'
 
 # subcategories for shows

--- a/website/core.py
+++ b/website/core.py
@@ -4,7 +4,7 @@ This module contains the core functionality of the application.
 from flask import (
     Blueprint, redirect, render_template, url_for
 )
-from .rss_client import RSSClient, ClientTimeoutError
+from .rss_client import RSSClient, ClientTimeoutError, InvalidResourceError
 from . import const
 
 CLIENT = RSSClient()
@@ -35,6 +35,11 @@ def movies(category, page):
             const.SERVER_ERROR_TEMPLATE,
             domains={'shows': CLIENT.show_categories,
                      'movies': CLIENT.movie_categories}), 500
+    except InvalidResourceError:
+        return render_template(
+            const.USER_ERROR_TEMPLATE,
+            domains={'shows': CLIENT.show_categories,
+                     'movies': CLIENT.movie_categories}), 404
 
 
 @BP.route('/shows/<category>/<page>')
@@ -53,6 +58,11 @@ def shows(category, page):
             const.SERVER_ERROR_TEMPLATE,
             domains={'shows': CLIENT.show_categories,
                      'movies': CLIENT.movie_categories}), 500
+    except InvalidResourceError:
+        return render_template(
+            const.USER_ERROR_TEMPLATE,
+            domains={'shows': CLIENT.show_categories,
+                     'movies': CLIENT.movie_categories}), 404
 
 
 @BP.route('/episodes/<show_id>/<page>')
@@ -71,6 +81,11 @@ def episodes(show_id, page):
             const.SERVER_ERROR_TEMPLATE,
             domains={'shows': CLIENT.show_categories,
                      'movies': CLIENT.movie_categories}), 500
+    except InvalidResourceError:
+        return render_template(
+            const.USER_ERROR_TEMPLATE,
+            domains={'shows': CLIENT.show_categories,
+                     'movies': CLIENT.movie_categories}), 404
 
 
 @BP.route('/sources/<episode_id>')
@@ -88,3 +103,8 @@ def sources(episode_id):
             const.SERVER_ERROR_TEMPLATE,
             domains={'shows': CLIENT.show_categories,
                      'movies': CLIENT.movie_categories}), 500
+    except InvalidResourceError:
+        return render_template(
+            const.USER_ERROR_TEMPLATE,
+            domains={'shows': CLIENT.show_categories,
+                     'movies': CLIENT.movie_categories}), 404

--- a/website/rss_client.py
+++ b/website/rss_client.py
@@ -21,6 +21,10 @@ class ClientTimeoutError(Exception):
     '''Custom exception class for timed out client requests'''
 
 
+class InvalidResourceError(Exception):
+    '''Custom exception class for invalid resources'''
+
+
 class RSSClientUtil:
     '''Class that assists with parsing responses from the RSS data source'''
     @staticmethod
@@ -120,6 +124,9 @@ class RSSClient:
                 'Request timed out fetching movies for %s, page %s',
                 category, page)
             raise ClientTimeoutError('Timeout fetching movies')
+        except AttributeError:
+            LOGGER.error('No movies found; invalid category: %s', category)
+            raise InvalidResourceError('No movies found')
 
     def get_shows(self, category, page):
         '''Gets shows for a category'''
@@ -141,6 +148,9 @@ class RSSClient:
                 'Request timed out fetching shows for %s, page %s',
                 category, page)
             raise ClientTimeoutError('Timeout fetching shows')
+        except AttributeError:
+            LOGGER.error('No shows found; invalid category: %s', category)
+            raise InvalidResourceError('No shows found')
 
     def get_episodes(self, show, page):
         '''Gets episodes for a show'''
@@ -162,6 +172,9 @@ class RSSClient:
                 'Request timed out fetching episodes for %s, page %s',
                 show, page)
             raise ClientTimeoutError('Timeout fetching episodes')
+        except AttributeError:
+            LOGGER.error('No episodes found; invalid show: %s', show)
+            raise InvalidResourceError('No episodes found')
 
     def get_sources(self, episode):
         '''Gets sources for an episode'''
@@ -180,3 +193,6 @@ class RSSClient:
             LOGGER.error(
                 'Request timed out fetching sources for episode %s', episode)
             raise ClientTimeoutError('Timeout fetching sources')
+        except AttributeError:
+            LOGGER.error('No sources found; invalid episode: %s', episode)
+            raise InvalidResourceError('No sources found')

--- a/website/templates/404.html
+++ b/website/templates/404.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+
+{% block title %}
+  Error - 故障
+{% endblock %}
+
+{% block header %}
+  <h1>Error - 故障</h1>
+{% endblock %}


### PR DESCRIPTION
a 5xx error used to be thrown if a user tries to access an invalid resource i.e. unknown episode id. this change now handles those types of cases and returns a 404 page to users

closes #25