### PR TITLE
feat: embed video player in the sources page

### DIFF
--- a/website/static/js/video-player.js
+++ b/website/static/js/video-player.js
@@ -1,0 +1,20 @@
+var app = new Vue({
+  el: '#player',
+  data: {
+    selected: '',
+    height: '',
+  },
+  beforeMount: function() {
+    var sources = this.$el.getElementsByTagName('button')
+    this.selected = sources[0].attributes['data-source'].value
+    this.height = window.innerHeight * 0.75
+  },
+  methods: {
+    render: function (event) {
+      this.selected = event.target.attributes['data-source'].value
+      var frame = this.$el.firstElementChild.firstElementChild
+      frame.contentWindow.location.replace(this.selected)
+    }
+  },
+  delimiters: ['[[',']]']
+})

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static',filename='css/custom.css') }}">
     <script type="text/javascript" src="{{ url_for('static',filename='js/jquery-3.0.0.min.js') }}" defer></script>
     <script type="text/javascript" src="{{ url_for('static',filename='js/bootstrap.min.js') }}" defer></script>
+    {% block scripts %}{% endblock %}
     <title>{% block title %}{% endblock %}</title>
   </head>
   <body class="h-100">

--- a/website/templates/core/sources.html
+++ b/website/templates/core/sources.html
@@ -1,19 +1,35 @@
 {% extends 'base.html' %}
 
+{% block scripts %}
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+  <script type="text/javascript" src="{{ url_for('static',filename='js/video-player.js') }}" defer></script>
+{% endblock %}
+
+{% block title %}
+  {{ response.title }}
+{% endblock %}
+
 {% block header %}
 	<h1>{{ response.title }}</h1>
 {% endblock %}
 
 {% block content %}
-  <ul class="list-group list-group-flush">
-  {% for source in response.items %}
-    <li>
-      <a href="{{ source.url }}"
-         class="text-bigger"
-         style="color:black;">
-       {{ source.title }}
-      </a>
-    </li>
-  {% endfor %}
-  </ul>
+  <div id="player">
+    <div id="video-player">
+      <iframe v-bind:src="selected"
+              v-bind:height="height"
+              width="100%"
+              allowfullscreen></iframe>
+    </div>
+
+    {% for source in response.items %}
+      <button type="button" 
+              class="btn" 
+              v-bind:class="{'btn-primary': selected == '{{ source.url }}'}" 
+              v-on:click="render" 
+              data-source="{{ source.url }}">
+        {{ source.title }}     
+      </button>
+    {% endfor %}
+  </div>
 {% endblock %}


### PR DESCRIPTION
This change allows users to view the video within the source page itself without having to leave the site itself. Buttons at the bottom indicate the different sources for the video and update the player in-place

closes #38